### PR TITLE
fix: Deprecate NI realTimeData

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Setup Java
-        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@cbe18979603527f12c7871a6eb04833ecf1548c7
+      uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -51,6 +51,6 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@cbe18979603527f12c7871a6eb04833ecf1548c7
+      uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}
       - name: Setup Java
-        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
         with:
           java-version: 21
           distribution: 'temurin'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: SARIF file
           path: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.3] - 2025-01-31
+
+### Added
+- `NumberInsight.advanced` overload without `realTimeData` parameter
+
+### Changed
+- Bumped Java SDK version to 8.16.0
+
+### Deprecated
+- `realTimeData` in `NumberInsight.advanced`
+
 ## [1.1.2] - 2024-12-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See all of our SDKs and integrations on the [Vonage Developer portal](https://de
 ## Installation
 Releases are published to [Maven Central](https://central.sonatype.com/artifact/com.vonage/server-sdk-kotlin).
 Instructions for your build system can be found in the snippets section.
-They're also available from [here](https://search.maven.org/artifact/com.vonage/server-sdk-kotlin/1.1.2/jar).
+They're also available from [here](https://search.maven.org/artifact/com.vonage/server-sdk-kotlin/1.1.3/jar).
 Release notes for each version can be found in the [changelog](CHANGELOG.md).
 
 Here are the instructions for including the SDK in your project:
@@ -63,7 +63,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk-kotlin:1.1.2")
+    implementation("com.vonage:server-sdk-kotlin:1.1.3")
 }
 ```
 
@@ -74,7 +74,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk-kotlin</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 </dependency>
 ```
 
@@ -160,8 +160,8 @@ including [**a searchable list of snippets**](https://github.com/Vonage/vonage-k
 
 The SDK is fully documented with [KDocs](https://kotlinlang.org/docs/kotlin-doc.html), so you should have complete
 documentation from your IDE. You may need to click "Download Sources" in IntelliJ to get the full documentation.
-Alternatively, you can browse the documentation  using a service like [Javadoc.io](https://javadoc.io/doc/com.vonage/server-sdk-kotlin/1.1.2/index.html),
-which renders the documentation for you from [the artifacts on Maven Central](https://repo.maven.apache.org/maven2/com/vonage/server-sdk-kotlin/1.1.2/).
+Alternatively, you can browse the documentation  using a service like [Javadoc.io](https://javadoc.io/doc/com.vonage/server-sdk-kotlin/1.1.3/index.html),
+which renders the documentation for you from [the artifacts on Maven Central](https://repo.maven.apache.org/maven2/com/vonage/server-sdk-kotlin/1.1.3/).
 
 For help with any specific APIs, refer to the relevant documentation on our [developer portal](https://developer.vonage.com/en/documentation),
 using the links provided in the [Supported APIs](#supported-apis) section. For completeness, you can also consult the

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk-kotlin</artifactId>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 
   <name>Vonage Kotlin Server SDK</name>
   <description>Kotlin client for Vonage APIs</description>
@@ -47,7 +47,7 @@
     <kotlin.compiler.languageVersion>2.0</kotlin.compiler.languageVersion>
     <kotlin.compiler.apiVersion>${kotlin.compiler.languageVersion}</kotlin.compiler.apiVersion>
     <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-    <kotlin.lib.version>2.1.0</kotlin.lib.version>
+    <kotlin.lib.version>2.1.10</kotlin.lib.version>
     <java.version>8</java.version>
   </properties>
 
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.vonage</groupId>
       <artifactId>server-sdk</artifactId>
-      <version>8.15.1</version>
+      <version>8.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/com/vonage/client/kt/NumberInsight.kt
+++ b/src/main/kotlin/com/vonage/client/kt/NumberInsight.kt
@@ -69,10 +69,31 @@ class NumberInsight internal constructor(private val client: InsightClient) {
      *
      * @return Advanced details about the number and insight metadata.
      */
+    @Deprecated("`realTimeData` is deprecated and will be removed in a future release.")
     fun advanced(number: String, countryCode: String? = null, cnam: Boolean = false,
-                 realTimeData: Boolean = false): AdvancedInsightResponse =
+                 realTimeData: Boolean): AdvancedInsightResponse =
         client.getAdvancedNumberInsight(AdvancedInsightRequest.builder().async(false)
             .number(number).country(countryCode).cnam(cnam).realTimeData(realTimeData).build()
+        )
+
+    /**
+     * Obtain advanced insight about a number synchronously. This is not recommended due to potential timeouts.
+     *
+     * @param number The phone number to look up in E.164 format.
+     *
+     * @param countryCode (OPTIONAL) The two-character country code in ISO 3166-1 alpha-2 format.
+     *
+     * @param cnam (OPTIONAL) Whether the name of the person who owns the phone number should be looked up
+     * and returned in the response. Set to true to receive phone number owner name in the response. This
+     * feature is available for US numbers only and incurs an additional charge.
+     *
+     * @return Advanced details about the number and insight metadata.
+     *
+     * @since 1.1.3
+     */
+    fun advanced(number: String, countryCode: String? = null, cnam: Boolean = false): AdvancedInsightResponse =
+        client.getAdvancedNumberInsight(AdvancedInsightRequest.builder().async(false)
+            .number(number).country(countryCode).cnam(cnam).build()
         )
 
     /**

--- a/src/main/kotlin/com/vonage/client/kt/Vonage.kt
+++ b/src/main/kotlin/com/vonage/client/kt/Vonage.kt
@@ -21,7 +21,7 @@ import com.vonage.client.VonageClient
 /**
  * Denotes the version of the Vonage Kotlin SDK being used, in SemVer format.
  */
-const val VONAGE_KOTLIN_SDK_VERSION = "1.1.2"
+const val VONAGE_KOTLIN_SDK_VERSION = "1.1.3"
 
 /**
  * The non-overridable user agent string used by the SDK.

--- a/src/test/kotlin/com/vonage/client/kt/NumberInsightTest.kt
+++ b/src/test/kotlin/com/vonage/client/kt/NumberInsightTest.kt
@@ -62,14 +62,14 @@ class NumberInsightTest : AbstractTest() {
         BASIC, STANDARD, ADVANCED, ADVANCED_ASYNC
     }
 
-    private fun mockInsight(type: InsightType, optionalParams: Boolean = false) {
+    private fun mockInsight(type: InsightType, optionalParams: Boolean = false, includeRtd: Boolean = false) {
         val expectedRequestParams = mutableMapOf<String, Any>("number" to toNumber)
         if (optionalParams) {
             expectedRequestParams["country"] = countryCode
             if (type != InsightType.BASIC) {
                 expectedRequestParams["cnam"] = cnam
             }
-            if (type == InsightType.ADVANCED) {
+            if (includeRtd) {
                 expectedRequestParams["real_time_data"] = realTimeData
             }
         }
@@ -262,7 +262,19 @@ class NumberInsightTest : AbstractTest() {
     @Test
     fun `advanced insight all params`() {
         mockInsight(InsightType.ADVANCED, true)
+        assertAdvancedResponse(client.advanced(toNumber, countryCode, cnam))
+    }
+
+    @Test
+    fun `advanced insight real time data all params`() {
+        mockInsight(InsightType.ADVANCED, true, true)
         assertAdvancedResponse(client.advanced(toNumber, countryCode, cnam, realTimeData))
+    }
+
+    @Test
+    fun `advanced insight real time data required params`() {
+        mockInsight(InsightType.ADVANCED, false, true)
+        assertAdvancedResponse(client.advanced(toNumber, realTimeData = realTimeData))
     }
 
     @Test


### PR DESCRIPTION
Bumps Java SDK to 8.16 and deprecates the `realTimeData` optional parameter in advanced number insight.