### PR TITLE
feat: Add support for custom requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - name: Send to Slack channels
         uses: slackapi/slack-github-action@v2.0.0
+        continue-on-error: true
         with:
           webhook: ${{ secrets[matrix.url] }}
           webhook-type: incoming-webhook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0] - 2025-04-30
+
+### Added
+- Support for custom HTTP requests via `Custom` client
+
+### Changed
+- Bumped Java SDK version to 9.2.0
+
 ## [2.0.0] - 2025-04-08
 Major release for compatibility with [Java SDK v9.0.0](https://github.com/Vonage/vonage-java-sdk/releases/tag/v9.0.0)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ You'll need to have [created a Vonage account](https://dashboard.nexmo.com/sign-
 - [Number Insight](https://developer.vonage.com/en/number-insight/overview)
 - [Number Management](https://developer.vonage.com/en/numbers/overview)
 - [Number Verification](https://developer.vonage.com/en/number-verification/overview)
-- [Pricing](https://developer.vonage.com/en/api/pricing)
 - [Redact](https://developer.vonage.com/en/redact/overview)
 - [SIM Swap](https://developer.vonage.com/en/sim-swap/overview)
 - [SMS](https://developer.vonage.com/en/messaging/sms/overview)
@@ -53,7 +52,7 @@ See all of our SDKs and integrations on the [Vonage Developer portal](https://de
 ## Installation
 Releases are published to [Maven Central](https://central.sonatype.com/artifact/com.vonage/server-sdk-kotlin).
 Instructions for your build system can be found in the snippets section.
-They're also available from [here](https://search.maven.org/artifact/com.vonage/server-sdk-kotlin/2.0.0/jar).
+They're also available from [here](https://search.maven.org/artifact/com.vonage/server-sdk-kotlin/2.1.0/jar).
 Release notes for each version can be found in the [changelog](CHANGELOG.md).
 
 Here are the instructions for including the SDK in your project:
@@ -63,7 +62,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk-kotlin:2.0.0")
+    implementation("com.vonage:server-sdk-kotlin:2.1.0")
 }
 ```
 
@@ -74,7 +73,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk-kotlin</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
@@ -160,12 +159,65 @@ including [**a searchable list of snippets**](https://github.com/Vonage/vonage-k
 
 The SDK is fully documented with [KDocs](https://kotlinlang.org/docs/kotlin-doc.html), so you should have complete
 documentation from your IDE. You may need to click "Download Sources" in IntelliJ to get the full documentation.
-Alternatively, you can browse the documentation  using a service like [Javadoc.io](https://javadoc.io/doc/com.vonage/server-sdk-kotlin/2.0.0/index.html),
-which renders the documentation for you from [the artifacts on Maven Central](https://repo.maven.apache.org/maven2/com/vonage/server-sdk-kotlin/2.0.0/).
+Alternatively, you can browse the documentation  using a service like [Javadoc.io](https://javadoc.io/doc/com.vonage/server-sdk-kotlin/2.1.0/index.html),
+which renders the documentation for you from [the artifacts on Maven Central](https://repo.maven.apache.org/maven2/com/vonage/server-sdk-kotlin/2.1.0/).
 
 For help with any specific APIs, refer to the relevant documentation on our [developer portal](https://developer.vonage.com/en/documentation),
 using the links provided in the [Supported APIs](#supported-apis) section. For completeness, you can also consult the
 [API specifications](https://developer.vonage.com/api) if you believe there are any discrepancies.
+
+### Custom Requests
+The [Java SDK supports custom HTTP requests](https://github.com/Vonage/vonage-java-sdk?tab=readme-ov-file#custom-requests),
+which this SDK builds upon. This allows you to use unsupported APIs with your own data models so long as they implement
+the `com.vonage.client.Jsonable` interface. Alternatively you can use `Map<String, *>` to represents the JSON structure.
+See [Custom.kt](src/main/kotlin/com/vonage/client/kt/Custom.kt) documentation for more details.
+Here are some examples for creating an application, all of which are equivalent.
+
+#### Map request, Map response
+```kotlin
+val response: Map<String, *> = client.custom.post(
+        "https://api.nexmo.com/v2/applications",
+        mapOf("name" to "Demo Application")
+)
+```
+
+#### Map request, Jsonable response
+```kotlin
+val response: Application = client.custom.post(
+        "https://api.nexmo.com/v2/applications",
+        mapOf("name" to "Demo Application")
+)
+```
+
+#### Jsonable request, Map response
+```kotlin
+val response: Map<String, *> = client.custom.post(
+        "https://api.nexmo.com/v2/applications",
+        com.vonage.client.application.Application.builder()
+            .name("Demo Application").build()
+)
+```
+
+#### Jsonable request, Jsonable response
+```kotlin
+val response: Application = client.custom.post(
+        "https://api.nexmo.com/v2/applications",
+        com.vonage.client.application.Application.builder()
+            .name("Demo Application").build()
+)
+```
+
+#### Caveats
+The same principle applies for all other supported HTTP methods. You can also use the `makeRequest` method for greater
+flexibility on the request and response types. In any case, you should **ALWAYS** use strong typing when assigning
+the result of the call, otherwise the compiler will not be able to infer the correct type and you will get a runtime
+exception. If you'd like to ignore the result, use `Void` rather than `Unit` or `Any`. For example in `DELETE` requests:
+
+```kotlin
+client.custom.delete<Void>("https://api.nexmo.com/accounts/:api_key/secrets/:secret_id")
+```
+
+You can see valid usage examples in [CustomTest.kt](src/test/kotlin/com/vonage/client/kt/CustomTest.kt).
 
 ## Frequently Asked Questions
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk-kotlin</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
 
   <name>Vonage Kotlin Server SDK</name>
   <description>Kotlin client for Vonage APIs</description>
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.vonage</groupId>
       <artifactId>server-sdk</artifactId>
-      <version>9.1.0</version>
+      <version>9.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
-      <version>3.12.1</version>
+      <version>3.13.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/kotlin/com/vonage/client/kt/Custom.kt
+++ b/src/main/kotlin/com/vonage/client/kt/Custom.kt
@@ -1,0 +1,149 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.kt
+
+import com.vonage.client.*
+import com.vonage.client.common.HttpMethod
+
+/**
+ * Custom client for making HTTP requests to APIs that are unsupported by this SDK.
+ * This will automatically handle authentication and (de)serialisation for you.
+ *
+ * Requests should be JSON-based; either a Map representation of the structure or an implementation of [Jsonable].
+ * Responses (i.e. the `R` parameter) may be one of the following:
+ * - `Map<String, *>` representation of the JSON response.
+ * - `Collection<*>` representation of the JSON response.
+ * - `String` representation of the response body.
+ * - A custom object that implements the [Jsonable] interface to parse the JSON response into.
+ * - [ByteArray] for binary response bodies.
+ * - [Void] for empty response bodies.
+ *
+ * Please note that you must ALWAYS explicitly provide the type parameters when calling methods on this client and
+ * also provide the type in the response assignment, otherwise the compiler won't be able to infer the correct type.
+ *
+ * @param internalJavaSDKCustomClient The underlying Java SDK implementation which this client delegates to.
+ *
+ * @since 2.1.0
+ */
+class Custom internal constructor(val internalJavaSDKCustomClient: CustomClient) {
+
+    /**
+     * Advanced method for making requests to APIs that are unsupported by this SDK. This is the most flexible option.
+     *
+     * @param requestMethod The HTTP method to use for the request as an enum.
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body, typically in JSON format. See [DynamicEndpoint.makeRequest] for acceptable types.
+     *
+     * @return The response body, which can be a Map, Collection, String, or custom object implementing [Jsonable].
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified T, reified R> makeRequest(requestMethod: HttpMethod, url: String, body: T): R =
+        internalJavaSDKCustomClient.makeRequest<T, R>(requestMethod, url, body)
+
+    /**
+     * Sends a `DELETE` request to the specified URL.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> delete(url: String): R =
+        internalJavaSDKCustomClient.delete<R>(url)
+
+    /**
+     * Sends a `GET` request to the specified URL.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> get(url: String): R =
+        internalJavaSDKCustomClient.get<R>(url)
+
+    /**
+     * Sends a `POST` request to the specified URL with a JSON body.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body as a [Jsonable] object.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> post(url: String, body: Jsonable): R =
+        internalJavaSDKCustomClient.post<R>(url, body)
+
+    /**
+     * Sends a `POST` request to the specified URL with a JSON body.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body in JSON format as a Map tree structure.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> post(url: String, body: Map<String, *>): R =
+        internalJavaSDKCustomClient.post<R>(url, body)
+
+    /**
+     * Sends a `PUT` request to the specified URL with a JSON body.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body as a [Jsonable] object.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> put(url: String, body: Jsonable): R =
+        internalJavaSDKCustomClient.put<R>(url, body)
+
+    /**
+     * Sends a `PUT` request to the specified URL with a JSON body.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body in JSON format as a Map tree structure.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> put(url: String, body: Map<String, *>): R =
+        internalJavaSDKCustomClient.put<R>(url, body)
+
+    /**
+     * Sends a `PATCH` request to the specified URL with a JSON body.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body as a [Jsonable] object.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> patch(url: String, body: Jsonable): R =
+        internalJavaSDKCustomClient.patch<R>(url, body)
+
+    /**
+     * Sends a `PATCH` request to the specified URL with a JSON body.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param body The request body in JSON format as a Map tree structure.
+     *
+     * @return The response body if present, typically as JSON. See the class documentation for acceptable types.
+     * @throws VonageApiResponseException If the HTTP response code is 400 or greater.
+     */
+    inline fun <reified R> patch(url: String, body: Map<String, *>): R =
+        internalJavaSDKCustomClient.patch<R>(url, body)
+}

--- a/src/main/kotlin/com/vonage/client/kt/Vonage.kt
+++ b/src/main/kotlin/com/vonage/client/kt/Vonage.kt
@@ -21,7 +21,7 @@ import com.vonage.client.VonageClient
 /**
  * Denotes the version of the Vonage Kotlin SDK being used, in SemVer format.
  */
-const val VONAGE_KOTLIN_SDK_VERSION = "2.0.0"
+const val VONAGE_KOTLIN_SDK_VERSION = "2.1.0"
 
 /**
  * The non-overridable user agent string used by the SDK.
@@ -67,6 +67,15 @@ class Vonage(config: VonageClient.Builder.() -> Unit) {
      * @return The [Conversion] client.
      */
     val conversion = Conversion(client.conversionClient)
+
+    /**
+     * Access to a client for making custom HTTP requests.
+     *
+     * @return The [Custom] client.
+     *
+     * @since 2.1.0
+     */
+    val custom = Custom(client.customClient)
 
     /**
      * Access to the Vonage Messages API.

--- a/src/test/kotlin/com/vonage/client/kt/AbstractTest.kt
+++ b/src/test/kotlin/com/vonage/client/kt/AbstractTest.kt
@@ -218,15 +218,19 @@ abstract class AbstractTest {
         contentType: ContentType? = null,
         accept: ContentType? = null,
         authType: AuthType? = null,
-        expectedParams: Map<String, Any>? = null): BuildingStep =
+        expectedParams: Map<String, Any>? = null,
+        includeMimeHeaders: Boolean = true
+    ): BuildingStep =
             wiremock.requestServerBuilderStep({
                 urlPath equalTo expectedUrl
                 headers contains "User-Agent" equalTo userAgent
-                if (contentType != null) {
-                    headers contains contentTypeHeaderName equalTo contentType.mime
-                }
-                if (accept != null) {
-                    headers contains "Accept" equalTo accept.mime
+                if (includeMimeHeaders) {
+                    if (contentType != null) {
+                        headers contains contentTypeHeaderName equalTo contentType.mime
+                    }
+                    if (accept != null) {
+                        headers contains "Accept" equalTo accept.mime
+                    }
                 }
 
                 if (authType != null) {

--- a/src/test/kotlin/com/vonage/client/kt/CustomTest.kt
+++ b/src/test/kotlin/com/vonage/client/kt/CustomTest.kt
@@ -1,0 +1,184 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.kt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.vonage.client.Jsonable
+import com.vonage.client.account.BalanceResponse
+import com.vonage.client.common.HttpMethod
+import kotlin.test.*
+
+class CustomTest : AbstractTest() {
+    private val client = vonage.custom
+    private val expectedUrl = "/unsupported"
+    private val absoluteUrl = wmBaseUrl + expectedUrl
+    private val bodyMap = mapOf(
+        "Hello" to "World",
+        "A" to 1,
+        "B" to listOf(2, 3),
+        "C" to true,
+        "d4" to mapOf(
+            "e5" to "f6",
+            "g7" to listOf("h8", "i9"),
+            "j10" to mapOf(
+                "k11" to 3.1415926,
+                "l13" to true,
+                "m14" to listOf(15, 16)
+            )
+        )
+    )
+    private val jsonableMap = mapOf("value" to 10.28, "autoReload" to false)
+    private val jsonableObj = Jsonable.fromJson<BalanceResponse>("{\"value\":10.28,\"autoReload\":false}")
+
+    private fun assertEqualsJsonableObject(response: BalanceResponse) {
+        assertNotNull(response)
+        assertEquals(10.28, response.value)
+        assertFalse(response.isAutoReload)
+    }
+
+    private fun mockGet() =
+        mockRequest(HttpMethod.GET, expectedUrl, authType = AuthType.JWT)
+            .mockReturn(200, bodyMap)
+
+    private fun mockPost() =
+        mockRequest(HttpMethod.POST, expectedUrl, authType = AuthType.JWT)
+            .mockReturn(200, bodyMap)
+
+    private fun mockPut() =
+        mockRequest(HttpMethod.PUT, expectedUrl, authType = AuthType.JWT)
+            .mockReturn(200, bodyMap)
+
+    private fun mockPatch() =
+        mockRequest(HttpMethod.PATCH, expectedUrl, authType = AuthType.JWT)
+            .mockReturn(200, bodyMap)
+
+    @Test
+    fun `make request DELETE with Jsonable body`() {
+        val request = mockRequest(HttpMethod.DELETE, expectedUrl,
+            authType = AuthType.JWT,
+            contentType = ContentType.APPLICATION_JSON,
+            expectedParams = jsonableMap
+        )
+
+        request.mockReturn(200, bodyMap)
+        val response = client.makeRequest<Jsonable, Map<String, *>>(
+            HttpMethod.DELETE, absoluteUrl, jsonableObj
+        )
+        assertEquals(bodyMap, response)
+
+        request.mockReturn(200, jsonableMap)
+        assertEqualsJsonableObject(client.makeRequest<Jsonable, BalanceResponse>(
+            HttpMethod.DELETE, absoluteUrl, jsonableObj
+        ))
+    }
+
+    @Test
+    fun `delete no response`() {
+        mockDelete(expectedUrl)
+        client.delete<Void>(absoluteUrl)
+    }
+
+    @Test
+    fun `get String response`() {
+        mockGet()
+        val response: String = client.get(absoluteUrl)
+        assertEquals(ObjectMapper().writeValueAsString(bodyMap), response)
+    }
+
+    @Test
+    fun `get Map response`() {
+        mockGet()
+        val response: Map<String, *> = client.get(absoluteUrl)
+        assertEquals(bodyMap, response)
+    }
+
+    @Test
+    fun `get Jsonable response`() {
+        mockGet(expectedUrl, expectedResponseParams = jsonableMap)
+        assertEqualsJsonableObject(client.get(absoluteUrl))
+    }
+
+    @Test
+    fun `post no response`() {
+        mockPost(expectedUrl)
+        client.post<Void>(absoluteUrl, bodyMap)
+        client.post<Void>(absoluteUrl, jsonableObj)
+        client.post<Void>(absoluteUrl, jsonableMap)
+    }
+
+    @Test
+    fun `post Jsonable response`() {
+        mockPost(expectedUrl, expectedResponseParams = jsonableMap)
+        assertEqualsJsonableObject(client.post(absoluteUrl, jsonableObj))
+        assertEqualsJsonableObject(client.post(absoluteUrl, jsonableMap))
+    }
+
+    @Test
+    fun `post Map response`() {
+        mockPost()
+        val response: Map<String, *> = client.post(absoluteUrl, bodyMap)
+        assertEquals(bodyMap, response)
+    }
+
+    @Test
+    fun `post String response`() {
+        mockPost()
+        val response: String = client.post(absoluteUrl, bodyMap)
+        assertEquals(ObjectMapper().writeValueAsString(bodyMap), response)
+    }
+
+    @Test
+    fun `put Jsonable response`() {
+        mockPut(expectedUrl, expectedResponseParams = jsonableMap)
+        assertEqualsJsonableObject(client.put(absoluteUrl, jsonableObj))
+        assertEqualsJsonableObject(client.put(absoluteUrl, jsonableMap))
+    }
+
+    @Test
+    fun `put Map response`() {
+        mockPut()
+        val response: Map<String, *> = client.put(absoluteUrl, bodyMap)
+        assertEquals(bodyMap, response)
+    }
+
+    @Test
+    fun `put String response`() {
+        mockPut()
+        val response: String = client.put(absoluteUrl, bodyMap)
+        assertEquals(ObjectMapper().writeValueAsString(bodyMap), response)
+    }
+
+    @Test
+    fun `patch Jsonable response`() {
+        mockPatch(expectedUrl, expectedResponseParams = jsonableMap)
+        assertEqualsJsonableObject(client.patch(absoluteUrl, jsonableObj))
+        assertEqualsJsonableObject(client.patch(absoluteUrl, jsonableMap))
+    }
+
+    @Test
+    fun `patch Map response`() {
+        mockPatch()
+        val response: Map<String, *> = client.patch(absoluteUrl, bodyMap)
+        assertEquals(bodyMap, response)
+    }
+
+    @Test
+    fun `patch String response`() {
+        mockPatch()
+        val response: String = client.patch(absoluteUrl, bodyMap)
+        assertEquals(ObjectMapper().writeValueAsString(bodyMap), response)
+    }
+}

--- a/src/test/kotlin/com/vonage/client/kt/VonageTest.kt
+++ b/src/test/kotlin/com/vonage/client/kt/VonageTest.kt
@@ -21,10 +21,12 @@ import kotlin.test.*
 
 class VonageTest {
 
+    @Ignore
     @Test
     fun `live testing placeholder`() {
         val client = Vonage { authFromEnv(); signatureSecret(null) }
-        println("Finished") // Place debug breakpoint here
+        val response : String = client.custom.get("https://www.example.com")
+        println(response) // Place debug breakpoint here
     }
 
     @Test


### PR DESCRIPTION
Following on from https://github.com/Vonage/vonage-java-sdk/pull/581, this PR allows users to make requests to unsupported Vonage APIs whilst automatically handling authentication, serialisation and response parsing, through a new `Custom` client.